### PR TITLE
README: Fix small typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ No, you can't. Only decryption is supported, because microcode has an RSA signat
 
 2. What kind CPUs are supported?
 
-A microcode update decryption key depends from CPU generation. We've extracted keys for Intel Gemini Lake (Goldmont Plus microarchitecture) and Intel Apolo Lake (Goldmont microarchitecture) generation. See [List of Supported CPUs](#list-of-supported-cpus)
+A microcode update decryption key depends from CPU generation. We've extracted keys for Intel Gemini Lake (Goldmont Plus microarchitecture) and Intel Apollo Lake (Goldmont microarchitecture) generation. See [List of Supported CPUs](#list-of-supported-cpus)
 
 3. How you had extracted the keys?
 


### PR DESCRIPTION
Found a small typo in the README

The change on the last line is just the GitHub editor adding a newline at the end (which is a good idea, anyway).